### PR TITLE
Add backward compat properties to CIFAR100 dataset classes

### DIFF
--- a/dataset/cifar100.py
+++ b/dataset/cifar100.py
@@ -35,8 +35,29 @@ def get_data_folder():
 
     return data_folder
 
+class CIFAR100BackCompat(datasets.CIFAR100):
+    """
+    CIFAR100Instance+Sample Dataset
+    """
 
-class CIFAR100Instance(datasets.CIFAR100):
+    @property
+    def train_labels(self):
+        return self.targets
+
+    @property
+    def test_labels(self):
+        return self.targets
+
+    @property
+    def train_data(self):
+        return self.data
+
+    @property
+    def test_data(self):
+        return self.data
+    
+
+class CIFAR100Instance(CIFAR100BackCompat):
     """CIFAR100Instance Dataset.
     """
     def __getitem__(self, index):
@@ -106,7 +127,7 @@ def get_cifar100_dataloaders(batch_size=128, num_workers=8, is_instance=False):
         return train_loader, test_loader
 
 
-class CIFAR100InstanceSample(datasets.CIFAR100):
+class CIFAR100InstanceSample(CIFAR100BackCompat):
     """
     CIFAR100Instance+Sample Dataset
     """


### PR DESCRIPTION
Hello, fan of your great work. In trying to reproduce your CIFAR100 results via README example commands, they would end up in an error, e.g.,

```bash
python train_student.py --path_t ./save/models/resnet32x4_vanilla/ckpt_epoch_240.pth --distill crd --model_s resnet8x4 -a 0 -b 0.8 --trial 1
Files already downloaded and verified
Traceback (most recent call last):
  File "train_student.py", line 345, in <module>
    main()
  File "train_student.py", line 157, in main
    mode=opt.mode)
  File "...RepDistiller/dataset/cifar100.py", line 211, in get_cifar100_dataloaders_sample
    percent=percent)
  File "...RepDistiller/dataset/cifar100.py", line 124, in __init__
    num_samples = len(self.train_data)
AttributeError: 'CIFAR100InstanceSample' object has no attribute 'train_data'
```

A simple change is to add four properties to a new class `CIFAR100BackCompat` to minimize the code changes, as submitted in this pull request. 

For additional background, here's the Torchvision's MNIST source for reference: [https://pytorch.org/docs/stable/_modules/torchvision/datasets/mnist.html#MNIST](https://pytorch.org/docs/stable/_modules/torchvision/datasets/mnist.html#MNIST)

relevant section:
```python
    @property
    def train_labels(self):
        warnings.warn("train_labels has been renamed targets")
        return self.targets

    @property
    def test_labels(self):
        warnings.warn("test_labels has been renamed targets")
        return self.targets

    @property
    def train_data(self):
        warnings.warn("train_data has been renamed data")
        return self.data

    @property
    def test_data(self):
        warnings.warn("test_data has been renamed data")
        return self.data
```

Tested the changes with:
```
torch==1.3.1
torchvision==0.4.2
```