### PR TITLE
Compatibility for `torch==1.12.1`

### DIFF
--- a/dataset/cifar100.py
+++ b/dataset/cifar100.py
@@ -40,21 +40,7 @@ class CIFAR100Instance(datasets.CIFAR100):
     """CIFAR100Instance Dataset.
     """
     def __getitem__(self, index):
-        if self.train:
-            img, target = self.train_data[index], self.train_labels[index]
-        else:
-            img, target = self.test_data[index], self.test_labels[index]
-
-        # doing this so that it is consistent with all other datasets
-        # to return a PIL Image
-        img = Image.fromarray(img)
-
-        if self.transform is not None:
-            img = self.transform(img)
-
-        if self.target_transform is not None:
-            target = self.target_transform(target)
-
+        img, target = super().__getitem__(index)
         return img, target, index
 
 

--- a/dataset/imagenet.py
+++ b/dataset/imagenet.py
@@ -39,13 +39,7 @@ class ImageFolderInstance(datasets.ImageFolder):
         Returns:
             tuple: (image, target) where target is class_index of the target class.
         """
-        path, target = self.imgs[index]
-        img = self.loader(path)
-        if self.transform is not None:
-            img = self.transform(img)
-        if self.target_transform is not None:
-            target = self.target_transform(target)
-
+        img, target = super().__getitem__(index)
         return img, target, index
 
 

--- a/helper/util.py
+++ b/helper/util.py
@@ -52,7 +52,7 @@ def accuracy(output, target, topk=(1,)):
 
         res = []
         for k in topk:
-            correct_k = correct[:k].view(-1).float().sum(0, keepdim=True)
+            correct_k = correct[:k].contiguous().view(-1).float().sum(0, keepdim=True)
             res.append(correct_k.mul_(100.0 / batch_size))
         return res
 


### PR DESCRIPTION
I checked that this works for recent versions(`torch==1.12.1`, `torchvision==0.13.1`) and old versions (`torch==1.3.1`, `torchvision==0.4.2`).

As mentioned in #14 , I made it backward-compatible with previous versions. 